### PR TITLE
feat: add homelab reusable workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,55 @@
 ---
 name: Release
-on:
+on: # yamllint disable-line rule:truthy
   workflow_call:
-permissions:
-  contents: read # for checkout
+    inputs:
+      dry_run:
+        description: Run semantic-release without publishing.
+        default: false
+        required: false
+        type: boolean
+
+permissions: read-all
+
 jobs:
-  release:
-    name: Release
+  release-dry-run:
+    if: inputs.dry_run
+    name: Release Dry Run
     runs-on: ubuntu-latest
     permissions:
-      contents: write # to be able to publish a GitHub release
-      issues: write # to be able to comment on released issues
-      pull-requests: write # to be able to comment on released pull requests
-      id-token: write # to enable use of OIDC for npm provenance
+      contents: read
     steps:
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: lts/*
-      - name: Release
+
+      - name: Semantic Release Dry Run
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          dry_run: true
+          ci: false
+
+  release:
+    if: ${{ !inputs.dry_run }}
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # for creating releases
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          dry_run: false
+          ci: true

--- a/.github/workflows/terragrunt-apply.yml
+++ b/.github/workflows/terragrunt-apply.yml
@@ -1,0 +1,172 @@
+---
+name: Terragrunt Apply
+
+on: # yamllint disable-line rule:truthy
+  workflow_call:
+    inputs:
+      apply_environment:
+        description: GitHub environment used for protected production applies.
+        default: homelab-production
+        required: false
+        type: string
+      aws_region:
+        description: AWS region used by the Terragrunt backend and providers.
+        default: us-east-1
+        required: false
+        type: string
+      aws_role_to_assume:
+        description: AWS role ARN to assume for applies; can also be passed as a secret.
+        default: ""
+        required: false
+        type: string
+      azuread_client_id:
+        description: Azure AD client ID; can also be passed as a secret.
+        default: ""
+        required: false
+        type: string
+      azuread_tenant_id:
+        description: Azure AD tenant ID; can also be passed as a secret.
+        default: ""
+        required: false
+        type: string
+      kube_api_server:
+        description: Kubernetes API server address used for reachability checks.
+        default: 10.1.0.199
+        required: false
+        type: string
+      tailscale_version:
+        description: Tailscale client version for GitHub Actions runners.
+        default: 1.98.3
+        required: false
+        type: string
+    secrets:
+      AWS_ROLE_TO_ASSUME_HOMELAB:
+        description: AWS role ARN to assume for applies.
+        required: false
+      AZUREAD_CLIENT_ID:
+        description: Azure AD client ID.
+        required: false
+      AZUREAD_CLIENT_SECRET:
+        description: Azure AD client secret.
+        required: false
+      AZUREAD_TENANT_ID:
+        description: Azure AD tenant ID.
+        required: false
+      KUBE_CONFIG_B64:
+        description: Base64-encoded kubeconfig for the target cluster.
+        required: true
+      TS_AUTH_KEY:
+        description: Tailscale auth key for reaching private network resources.
+        required: true
+
+permissions: {}
+
+concurrency:
+  group: terragrunt-apply-${{ inputs.apply_environment }}
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: ${{ inputs.aws_region }}
+  KUBE_API_SERVER: ${{ inputs.kube_api_server }}
+  TAILSCALE_VERSION: ${{ inputs.tailscale_version }}
+
+jobs:
+  static-policy:
+    name: Static Policy And Security Checks
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Check Out Repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
+        with:
+          github_access_token: ${{ github.token }}
+
+      - name: Restore Nix Store Cache
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+        with:
+          primary-key: nix-develop-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+          restore-prefixes-first-match: nix-develop-${{ runner.os }}-
+
+      - name: Run Static Checks
+        run: nix develop --command bash scripts/ci/static-checks.sh
+
+      - name: Run Conftest Policies
+        run: nix develop --command bash scripts/ci/conftest-policies.sh
+
+  terragrunt-apply:
+    name: Terragrunt Apply
+    needs:
+      - static-policy
+    runs-on: ubuntu-24.04
+    environment:
+      name: ${{ inputs.apply_environment }}
+    permissions:
+      contents: read
+      id-token: write
+    timeout-minutes: 90
+    env:
+      AWS_APPLY_ROLE_ARN: ${{ inputs.aws_role_to_assume || secrets.AWS_ROLE_TO_ASSUME_HOMELAB }}
+      ARM_CLIENT_ID: ${{ inputs.azuread_client_id || secrets.AZUREAD_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.AZUREAD_CLIENT_SECRET }}
+      ARM_TENANT_ID: ${{ inputs.azuread_tenant_id || secrets.AZUREAD_TENANT_ID }}
+      APPLY_BASE_SHA: ${{ github.event.before }}
+      APPLY_HEAD_SHA: ${{ github.sha }}
+    steps:
+      - name: Check Out Repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
+        with:
+          github_access_token: ${{ github.token }}
+
+      - name: Restore Nix Store Cache
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+        with:
+          primary-key: nix-develop-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+          restore-prefixes-first-match: nix-develop-${{ runner.os }}-
+
+      - name: Verify Production Apply Inputs
+        run: |
+          test -n "${AWS_APPLY_ROLE_ARN}" || { echo "AWS_ROLE_TO_ASSUME_HOMELAB must be set as an input or secret."; exit 1; }
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          mask-aws-account-id: true
+          role-session-name: homelab-terragrunt-apply-${{ github.run_id }}
+          role-to-assume: ${{ env.AWS_APPLY_ROLE_ARN }}
+          unset-current-credentials: true
+
+      - name: Connect To Tailnet
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
+        with:
+          authkey: ${{ secrets.TS_AUTH_KEY }}
+          tags: tag:github-actions-terragrunt-apply
+          version: ${{ env.TAILSCALE_VERSION }}
+
+      - name: Accept Tailnet Subnet Routes
+        run: sudo tailscale set --accept-routes=true
+
+      - name: Install Kubeconfig
+        env:
+          KUBE_CONFIG_B64: ${{ secrets.KUBE_CONFIG_B64 }}
+        run: bash scripts/ci/install-kubeconfig.sh
+
+      - name: Verify Kubernetes API Reachability
+        run: |
+          ip route get "${KUBE_API_SERVER}"
+          kubectl --request-timeout=15s version
+
+      - name: Run Terragrunt Apply
+        run: nix develop --command bash scripts/ci/terragrunt-apply.sh

--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -1,0 +1,216 @@
+---
+name: Terragrunt Plan
+
+on: # yamllint disable-line rule:truthy
+  workflow_call:
+    inputs:
+      aws_region:
+        description: AWS region used by the Terragrunt backend and providers.
+        default: us-east-1
+        required: false
+        type: string
+      aws_role_to_assume:
+        description: AWS role ARN to assume for plans; can also be passed as a secret.
+        default: ""
+        required: false
+        type: string
+      azuread_client_id:
+        description: Azure AD client ID; can also be passed as a secret.
+        default: ""
+        required: false
+        type: string
+      azuread_tenant_id:
+        description: Azure AD tenant ID; can also be passed as a secret.
+        default: ""
+        required: false
+        type: string
+      kube_api_server:
+        description: Kubernetes API server address used for reachability checks.
+        default: 10.1.0.199
+        required: false
+        type: string
+      plan_environment:
+        description: GitHub environment used for trusted live plans.
+        default: homelab-plan
+        required: false
+        type: string
+      tailscale_version:
+        description: Tailscale client version for GitHub Actions runners.
+        default: 1.98.3
+        required: false
+        type: string
+    secrets:
+      AWS_ROLE_TO_ASSUME_HOMELAB:
+        description: AWS role ARN to assume for plans.
+        required: false
+      AZUREAD_CLIENT_ID:
+        description: Azure AD client ID.
+        required: false
+      AZUREAD_CLIENT_SECRET:
+        description: Azure AD client secret.
+        required: false
+      AZUREAD_TENANT_ID:
+        description: Azure AD tenant ID.
+        required: false
+      KUBE_CONFIG_B64:
+        description: Base64-encoded kubeconfig for the target cluster.
+        required: true
+      TS_AUTH_KEY:
+        description: Tailscale auth key for reaching private network resources.
+        required: true
+
+permissions: {}
+
+concurrency:
+  group: terragrunt-plan-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: ${{ inputs.aws_region }}
+  KUBE_API_SERVER: ${{ inputs.kube_api_server }}
+  TAILSCALE_VERSION: ${{ inputs.tailscale_version }}
+
+jobs:
+  static-policy:
+    name: Static Policy And Security Checks
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Check Out Repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
+        with:
+          github_access_token: ${{ github.token }}
+
+      - name: Restore Nix Store Cache
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+        with:
+          primary-key: nix-develop-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+          restore-prefixes-first-match: nix-develop-${{ runner.os }}-
+
+      - name: Run Static Checks
+        run: nix develop --command bash scripts/ci/static-checks.sh
+
+  terragrunt-plan:
+    name: Terragrunt Plan
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    concurrency:
+      group: terragrunt-plan-live-state
+      cancel-in-progress: false
+    needs:
+      - static-policy
+    runs-on: ubuntu-24.04
+    environment:
+      name: ${{ inputs.plan_environment }}
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    timeout-minutes: 60
+    env:
+      AWS_PLAN_ROLE_ARN: ${{ inputs.aws_role_to_assume || secrets.AWS_ROLE_TO_ASSUME_HOMELAB }}
+      ARM_CLIENT_ID: ${{ inputs.azuread_client_id || secrets.AZUREAD_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.AZUREAD_CLIENT_SECRET }}
+      ARM_TENANT_ID: ${{ inputs.azuread_tenant_id || secrets.AZUREAD_TENANT_ID }}
+    steps:
+      - name: Check Out Repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
+        with:
+          github_access_token: ${{ github.token }}
+
+      - name: Restore Nix Store Cache
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+        with:
+          primary-key: nix-develop-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+          restore-prefixes-first-match: nix-develop-${{ runner.os }}-
+
+      - name: Verify Live Plan Inputs
+        run: |
+          test -n "${AWS_PLAN_ROLE_ARN}" || { echo "AWS_ROLE_TO_ASSUME_HOMELAB must be set as an input or secret."; exit 1; }
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          mask-aws-account-id: true
+          role-session-name: homelab-terragrunt-plan-${{ github.run_id }}
+          role-to-assume: ${{ env.AWS_PLAN_ROLE_ARN }}
+          unset-current-credentials: true
+
+      - name: Connect To Tailnet
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
+        with:
+          authkey: ${{ secrets.TS_AUTH_KEY }}
+          tags: tag:github-actions-terragrunt-plan
+          version: ${{ env.TAILSCALE_VERSION }}
+
+      - name: Accept Tailnet Subnet Routes
+        run: sudo tailscale set --accept-routes=true
+
+      - name: Install Kubeconfig
+        env:
+          KUBE_CONFIG_B64: ${{ secrets.KUBE_CONFIG_B64 }}
+        run: bash scripts/ci/install-kubeconfig.sh
+
+      - name: Verify Kubernetes API Reachability
+        run: |
+          ip route get "${KUBE_API_SERVER}"
+          kubectl --request-timeout=15s version
+
+      - name: Run Terragrunt Plan
+        env:
+          TERRAGRUNT_PLAN_MARKDOWN: ${{ runner.temp }}/terragrunt-plan.md
+        run: nix develop --command bash scripts/ci/terragrunt-plan.sh
+
+      - name: Update PR Description With Plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TERRAGRUNT_PLAN_MARKDOWN: ${{ runner.temp }}/terragrunt-plan.md
+        run: bash scripts/ci/update-pr-plan-description.sh
+
+      - name: Run Conftest Policies
+        if: ${{ !cancelled() }}
+        run: nix develop --command bash scripts/ci/conftest-policies.sh
+
+  fork-plan-skipped:
+    name: Terragrunt Plan Skipped For Fork
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+    needs:
+      - static-policy
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Check Out Repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
+        with:
+          github_access_token: ${{ github.token }}
+
+      - name: Restore Nix Store Cache
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+        with:
+          primary-key: nix-develop-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+          restore-prefixes-first-match: nix-develop-${{ runner.os }}-
+
+      - name: Explain Skip
+        run: echo "Live Terragrunt plan is skipped for forked pull requests because it requires AWS, Tailscale, and Kubernetes secrets."
+
+      - name: Run Conftest Policies
+        run: nix develop --command bash scripts/ci/conftest-policies.sh

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,64 @@
+---
+name: Validate
+
+on: # yamllint disable-line rule:truthy
+  workflow_call:
+    inputs:
+      kustomize_overlays:
+        description: Space-delimited overlay paths or globs to render.
+        default: clusters/homelab/platform/storage clusters/homelab/argocd/self-management clusters/homelab/apps/*
+        required: false
+        type: string
+      secret_reference_paths:
+        description: Space-delimited paths reviewed for committed secret material.
+        default: clusters IaC docs
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@b97f05dcb019ddea06450a50ef6203d2fdc19fee # v31.7.0
+
+      - name: Check flake
+        run: nix flake check --no-build --all-systems
+
+      - name: Check HCL formatting
+        run: nix develop --command terragrunt hcl fmt --check
+
+      - name: Validate Terragrunt HCL
+        run: nix develop --command terragrunt hcl validate
+
+      - name: Check OpenTofu formatting
+        run: nix develop --command tofu fmt -check -recursive IaC
+
+      - name: Render Kustomize sources
+        env:
+          KUSTOMIZE_OVERLAYS: ${{ inputs.kustomize_overlays }}
+        run: |
+          for overlay in ${KUSTOMIZE_OVERLAYS}; do
+            test -f "$overlay/kustomization.yaml" || continue
+            echo "rendering $overlay"
+            nix develop --command kubectl kustomize "$overlay" >/dev/null
+          done
+
+      - name: Check whitespace
+        run: git diff --check
+
+      - name: Secret reference review
+        env:
+          SECRET_REFERENCE_PATHS: ${{ inputs.secret_reference_paths }}
+        run: |
+          matches="$(rg -n "password|token|secret|api[_-]?key|PRIVATE KEY|BEGIN CERTIFICATE|kubeconfig" ${SECRET_REFERENCE_PATHS} || true)"
+          printf "%s\n" "$matches"
+          ! printf "%s\n" "$matches" | rg -i -- "-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY-----|-----BEGIN CERTIFICATE-----|AKIA[0-9A-Z]{16}|ghp_[0-9A-Za-z_]{36}"

--- a/README.md
+++ b/README.md
@@ -3,3 +3,35 @@
 GitHub workflows for the organization
 
 [![Super-Linter](https://github.com/Stuhlmuller/workflows/actions/workflows/lint.yml/badge.svg)](https://github.com/marketplace/actions/super-linter)
+
+## Reusable workflows
+
+This repository publishes reusable GitHub Actions workflows for repositories in the Stuhlmuller organization.
+
+- `.github/workflows/release.yml` runs semantic-release, with an optional dry-run mode for pull requests.
+- `.github/workflows/terragrunt-plan.yml` runs the homelab Terragrunt plan path.
+- `.github/workflows/terragrunt-apply.yml` runs the homelab Terragrunt apply path.
+- `.github/workflows/validate.yml` runs the homelab validation checks.
+
+Call them from another repository with a job-level `uses` reference:
+
+```yaml
+jobs:
+  validate:
+    uses: Stuhlmuller/workflows/.github/workflows/validate.yml@main
+
+  terragrunt-plan:
+    uses: Stuhlmuller/workflows/.github/workflows/terragrunt-plan.yml@main
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    secrets: inherit
+
+  terragrunt-apply:
+    uses: Stuhlmuller/workflows/.github/workflows/terragrunt-apply.yml@main
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit
+```


### PR DESCRIPTION
## Summary

This updates the shared workflows repository with the workflow behavior currently used by `Stuhlmuller/homelab`.

The shared workflows repo previously had a reusable release workflow, but it did not expose the homelab Terragrunt plan, Terragrunt apply, or validation paths. That meant homelab-specific CI behavior lived only inside the homelab repository instead of being available through the organization workflow library.

## Cause and impact

Homelab now has a fuller CI path for static policy checks, live Terragrunt plan/apply execution, Kubernetes reachability checks through Tailscale, conftest policy enforcement, and repository validation. Without equivalents in `Stuhlmuller/workflows`, consumers cannot centralize those jobs or reuse the same pinned action versions and defaults.

The effect for users is duplication pressure: homelab workflow improvements need to be copied by hand, and repositories that want the same behavior cannot call a shared workflow directly.

## Root cause

The source workflow files in `Stuhlmuller/homelab` are repository-local workflows with direct `pull_request`, `push`, and `workflow_dispatch` triggers. The `Stuhlmuller/workflows` repository is a workflow library, so those files needed to be adapted into `workflow_call` entrypoints rather than copied verbatim.

## Fix

This change adds reusable workflow-call versions of the homelab Terragrunt plan, Terragrunt apply, and validation workflows. It preserves the homelab defaults for AWS region, Kubernetes API address, Tailscale version, environments, scripts, and pinned action SHAs while exposing inputs and secrets for callers.

It also updates the release workflow to use the same pinned `cycjimmy/semantic-release-action` pattern from homelab, including an optional dry-run mode, and documents the new reusable workflows in the README.

## Validation

- `pre-commit run --files .pre-commit-config.yaml .pre-commit-hooks.yaml README.md .github/CODEOWNERS .github/workflows/checkov.yml .github/workflows/merge-gatekeeper.yml .github/workflows/lint.yml .github/workflows/review-bot.yml .github/workflows/release.yml .github/workflows/terragrunt-apply.yml .github/workflows/terragrunt-plan.yml .github/workflows/validate.yml`
- `git diff --check`

