### PR TITLE
ci: tune super-linter pull request runs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,11 @@ name: Lint
 on: # yamllint disable-line rule:truthy
   pull_request:
 permissions: {}
+
+concurrency:
+  group: super-linter-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Lint
@@ -46,4 +51,5 @@ jobs:
           # To report GitHub Actions status checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISABLE_ERRORS: true
+          DEFAULT_BRANCH: ${{ github.event.pull_request.base.ref }}
           VALIDATE_ALL_CODEBASE: false


### PR DESCRIPTION
## Summary

This follow-up tunes the Super-Linter pull request workflow after the image-cache change landed. It adds workflow-level concurrency so newer runs for the same pull request cancel older in-progress lint runs, and it passes Super-Linter the pull request base branch through `DEFAULT_BRANCH`.

The user-visible effect is less wasted CI time on rapid PR updates and a clearer branch target for Super-Linter when it decides which files changed. The concurrency group is keyed by pull request number with a ref fallback, so unrelated pull requests can still lint independently while stale runs for the same PR are cancelled.

The root cause was that the Super-Linter workflow had no concurrency guard, so older runs could continue after their results were superseded by newer commits. It also relied on Super-Linter defaults for the repository default branch rather than explicitly using the PR base branch provided by the pull request event.

## Validation

Validated with:

- `pre-commit run check-yaml --files .github/workflows/lint.yml`
- `zizmor .github/workflows/lint.yml`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/lint.yml`
- `git diff --check --cached`

The signed commit also ran the repository pre-commit hooks successfully.
