### PR TITLE
ci: remove super-linter image cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,4 +33,5 @@ jobs:
           DISABLE_ERRORS: true
           DEFAULT_BRANCH: ${{ github.event.pull_request.base.ref }}
           ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false
+          SAVE_SUPER_LINTER_SUMMARY: true
           VALIDATE_ALL_CODEBASE: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,6 @@ jobs:
       packages: read
       # To report GitHub Actions status checks
       statuses: write
-    env:
-      LINTER_IMAGE: ghcr.io/super-linter/super-linter:v8.6.0
-      LINTER_IMAGE_CACHE_DIR: /tmp/super-linter-image
-      LINTER_IMAGE_CACHE_FILE: /tmp/super-linter-image/v8.6.0.tar
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -29,22 +25,6 @@ jobs:
           # list of files that changed across commits
           fetch-depth: 0
           persist-credentials: false
-      - name: Cache Super-linter image
-        id: super-linter-image-cache
-        # v5.0.3
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # yamllint disable-line rule:line-length
-        with:
-          path: ${{ env.LINTER_IMAGE_CACHE_DIR }}
-          key: ${{ runner.os }}-super-linter-image-v8.6.0
-      - name: Load Super-linter image
-        if: steps.super-linter-image-cache.outputs.cache-hit == 'true'
-        run: docker load --input "${LINTER_IMAGE_CACHE_FILE}"
-      - name: Pull Super-linter image
-        if: steps.super-linter-image-cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p "${LINTER_IMAGE_CACHE_DIR}"
-          docker pull "${LINTER_IMAGE}"
-          docker save --output "${LINTER_IMAGE_CACHE_FILE}" "${LINTER_IMAGE}"
       - name: Super-linter
         uses: super-linter/super-linter@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,4 +32,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISABLE_ERRORS: true
           DEFAULT_BRANCH: ${{ github.event.pull_request.base.ref }}
+          ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false
           VALIDATE_ALL_CODEBASE: false


### PR DESCRIPTION
## Summary

This removes the Super-Linter container image cache that was added to `.github/workflows/lint.yml` and cleans up the Super-Linter summary configuration warning.

Live GitHub Actions timing showed that the Super-Linter Docker action image is pulled by the runner before any workflow steps execute. That means the later `actions/cache` restore step cannot prevent the initial Docker action image pull. The workflow was then doing extra work by restoring a tar cache, manually pulling the same image, saving it, and running a post-job cache save.

The fix keeps the useful PR behavior from the prior tuning work: stale runs are still cancelled through workflow-level concurrency, and Super-Linter still gets the pull request base branch through `DEFAULT_BRANCH`. It removes the redundant image tar cache and manual Docker load/pull/save steps.

The workflow also now disables Super-Linter pull request summary comments while setting `SAVE_SUPER_LINTER_SUMMARY: true`, which satisfies the Actions step summary path without requiring PR comment permissions. This removes the warning about summary output configuration.

## Validation

Validated locally with:

- `pre-commit run check-yaml --files .github/workflows/lint.yml`
- `zizmor .github/workflows/lint.yml`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/lint.yml`
- `git diff --check`

The signed commits also ran the repository pre-commit hooks successfully.

## Run Evidence

Recent `lint.yml` runs in this repository completed in a few minutes, not six hours:

- `27055549818`, PR #61, `3m15s`
- `27055263176`, PR #60, `4m2s`

After removing the cache path and fixing the summary settings, PR #62's latest Lint run passed in `1m47s`. A targeted log check confirmed `ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false` and `SAVE_SUPER_LINTER_SUMMARY: true`; the prior `SAVE_SUPER_LINTER_SUMMARY` warning did not reappear.
